### PR TITLE
Get marathon package from PyPi in stead of github

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ itsdangerous==0.24
 prometheus_client==0.0.13
 wsgiref==0.1.2
 requests==2.9.1
--e git+https://github.com/bergerx/marathon-python.git#egg=Package
+marathon==0.8.2


### PR DESCRIPTION
I'm having issue with the current docker image (https://hub.docker.com/r/bergerx/prom-marathon-app-exporter/) which gives me a 500 internal server error. It seems to crash on this line https://github.com/bergerx/prom_marathon_app_exporter/blob/master/collector.py#L54

Using the marathon package from PyPi seems to solve it for me.

The package on PyPi comes from this repo https://github.com/thefactory/marathon-python which is updated more recently.
