### PR TITLE
Start nginx in foreground

### DIFF
--- a/supervisor-app.conf
+++ b/supervisor-app.conf
@@ -1,2 +1,3 @@
 [program:nginx-app]
-command = /usr/sbin/nginx
+command = /usr/sbin/nginx -g 'daemon off;'
+


### PR DESCRIPTION
otherwise, supervisord will try over and over to start another nginx instance (which does not crash the docker container but still keeps it busy restarting nginx for no reason).

Thanks for the exporter
